### PR TITLE
Fix retranslation settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 * Renamed `freeze` variable to `disableTranslations`.
+* Re-translation auto-detection is now off by default, and can be activated by
+  `activateAutoDetect` variable.
 
 
 ## [0.1.0] - 2022-07-06

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [Unreleased]
+### Changed
+* Renamed `freeze` variable to `disableTranslations`.
+
+
 ## [0.1.0] - 2022-07-06
 Initial release.
 
 
+[Unreleased]: https://github.com/DeepLcom/google-sheets-example/compare/v0.1.0...HEAD
 [0.1.0]: https://github.com/DeepLcom/google-sheets-example/releases/tag/v0.1.0

--- a/DeepL.gs
+++ b/DeepL.gs
@@ -25,8 +25,8 @@ SOFTWARE.
 /* Please change the line below */
 const authKey = "b493b8ef-0176-215d-82fe-e28f182c9544:fx"; // Replace with your authentication key
 
-/* Change the line below to stop cells from re-translating */
-const freeze = false; // Set to true to stop re-translation
+/* Change the line below to disable all translations. */
+const disableTranslations = false; // Set to true to stop translations.
 
 /* You shouldn't need to modify the lines below here */
 
@@ -49,8 +49,8 @@ function DeepLTranslate(input, sourceLang, targetLang, glossaryId) {
     // Check the current cell to detect recalculations due to reopening the sheet
     const cell = SpreadsheetApp.getActiveSpreadsheet().getActiveSheet().getCurrentCell();
 
-    if (freeze) {
-        Logger.log("freeze is active, skipping DeepL translation request");
+    if (disableTranslations) {
+        Logger.log("disableTranslations is active, skipping DeepL translation request");
         return cell.getDisplayValue();
     }
 

--- a/DeepL.gs
+++ b/DeepL.gs
@@ -28,6 +28,9 @@ const authKey = "b493b8ef-0176-215d-82fe-e28f182c9544:fx"; // Replace with your 
 /* Change the line below to disable all translations. */
 const disableTranslations = false; // Set to true to stop translations.
 
+/* Change the line below to activate auto-detection of re-translations. */
+const activateAutoDetect = false; // Set to true to enable auto-detection of re-translation.
+
 /* You shouldn't need to modify the lines below here */
 
 /**
@@ -54,7 +57,9 @@ function DeepLTranslate(input, sourceLang, targetLang, glossaryId) {
         return cell.getDisplayValue();
     }
 
-    if (cell.getDisplayValue() !== "" && cell.getDisplayValue() !== "Loading...") {
+    if (activateAutoDetect &&
+            cell.getDisplayValue() !== "" &&
+            cell.getDisplayValue() !== "Loading...") {
         Logger.log("Detected cell-recalculation, skipping DeepL translation request");
         return cell.getDisplayValue();
     }

--- a/README.md
+++ b/README.md
@@ -242,11 +242,15 @@ At the top of the provided script ([DeepL.gs](DeepL.gs)), there is a
 `true` and save the script, the `DeepLTranslate` function will be disabled and
 already-translated cells will not be re-translated.
 
-### Built-in re-calculation detection
+### Built-in re-translation detection
 
-Finally, automatic re-calculation detection is built-in to the script, however
-unfortunately tests have shown the detection technique used is not fully
-reliable.
+Automatic re-translation detection is built-in to the script, however it is
+disabled by default because unfortunately tests have shown the detection
+technique used is not fully reliable.
+
+There is an `activateAutoDetect` variable at the top of the provided script
+([DeepL.gs](DeepL.gs)) to activate the automatic re-translation detection. Set
+it to `true` to enable this feature.
 
 ## Contributing feedback and improvements
 

--- a/README.md
+++ b/README.md
@@ -235,12 +235,12 @@ You can also use the keyboard shortcut applicable to your operating system.
 
 ![Using Paste special -> Values only](docs/Google_Paste_Values.png)
 
-### Script `freeze` Flag
+### Script `disableTranslations` Flag
 
-At the top of the provided script ([DeepL.gs](DeepL.gs)), there is a `freeze`
-flag to disable all translations. If you set the flag to `true` and save the
-script, the `DeepLTranslate` function will be disabled and already-translated
-cells will not be re-translated.
+At the top of the provided script ([DeepL.gs](DeepL.gs)), there is a
+`disableTranslations` variable to disable all translations. If you set it to
+`true` and save the script, the `DeepLTranslate` function will be disabled and
+already-translated cells will not be re-translated.
 
 ### Built-in re-calculation detection
 


### PR DESCRIPTION
Rename one of the configuration variables, and add another one `activateAutoDetect` to activate the auto-detection feature (it is now off by default).